### PR TITLE
Reuse UDP socket while flushing stats

### DIFF
--- a/backends/gossip_girl.js
+++ b/backends/gossip_girl.js
@@ -6,6 +6,7 @@ function GossipGirl(startupTime, config, emitter) {
   self.config = config.gossip_girl || []
   self.statsd_config = config
   self.ignorable = [ "statsd.packets_received", "statsd.bad_lines_seen", "statsd.packet_process_time" ]
+  self.sock = dgram.createSocket("udp4")
 
   emitter.on('flush', function(time_stamp, metrics) { self.process(time_stamp, metrics); })
 }
@@ -34,7 +35,6 @@ GossipGirl.prototype.process = function(time_stamp, metrics) {
     timers:   { data: metrics.timers,   suffix: "ms", name: "timer" }
   }
 
-  self.sock = dgram.createSocket("udp4")
   for (var i = 0; i < hosts.length; i++) {
     for (type in stats_map) {
       stats = stats_map[type]
@@ -57,6 +57,11 @@ GossipGirl.prototype.process = function(time_stamp, metrics) {
     }
   }
 }
+
+GossipGirl.prototype.stop = function(cb) {
+  this.sock.close();
+  cb();
+};
 
 exports.init = function(startupTime, config, events) {
   var instance = new GossipGirl(startupTime, config, events)


### PR DESCRIPTION
Otherwise after each flush total process connection count is constantly increasing and is never cleaned up.